### PR TITLE
Fix margin left when column has siblings

### DIFF
--- a/templates/assets/less/core/grid.less
+++ b/templates/assets/less/core/grid.less
@@ -44,7 +44,7 @@
 @{column-class} {
     float: left;
 
-    + & {
+    + @{column-class} {
         margin-left: @total-width*(@gutter-width/@gridsystem-width);
     }
 }


### PR DESCRIPTION
look like less cant use a variable for a sibling with "+ &"
